### PR TITLE
Couple of fixes to allow to code to work on windows and make it more flexible

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+*.Rproj

--- a/R/NARRdownloadNetCDF.R
+++ b/R/NARRdownloadNetCDF.R
@@ -56,7 +56,7 @@ NARRdownloadNetCDF <- function(interval='daily',
     # create url for downloading
     file_url <- paste(url, variable,'.',yearnum,'.nc', sep='')
     destination_file <- paste(destination, variable,'.',yearnum,'.nc', sep='')
-    utils::download.file(file_url, destination_file, method='auto', quiet = quiet, mode = "w",
+    utils::download.file(file_url, destination_file, method='auto', quiet = quiet, mode = "wb",
                  cacheOK = TRUE,
                  extra = getOption("download.file.extra"))
   }

--- a/R/NARRdownloadNetCDF.R
+++ b/R/NARRdownloadNetCDF.R
@@ -4,7 +4,14 @@
 #' @param startYear Optional. The first year to download. Default is 1979.
 #' @param endYear Optional. The last year to download. Default is 1979.
 #' @param destination Optional. The destination directory for the downloaded files. The default is the current directory.
-#' @param variable Optional. The variable to be downloaded. Acceptable values are 'precip' (the default), 'temp', 'rh', 'wind', 'qli' and 'qli'.
+#' @param variable Optional. The variable to be downloaded. Acceptable values are one of c("acpcp", "air", "albedo", "apcp",
+#'  "bgrun", "bmixl", "cape", "ccond", "cdcon", "cdlyr", "cfrzr", "cicep", "cin", "cnwat", "crain", "csnow", "dlwrf", 
+#'  "dpt", "dswrf", "evap", "gflux", "hcdc", "hgt", "hlcy", "hpbl", "lcdc", "lftx4", "lhtfl", "mcdc", "mconv", 
+#'  "mslet", "mstav", "pevap", "pottmp", "pr_wtr", "prate", "pres", "prmsl", "rcq", "rcs", "rcsol", "rct", "rhum",
+#'  "shtfl", "shum", "snod", "snohf", "snom", "snowc", "soilm", "ssrun", "tcdc", "tke", "ulwrf", "ustm", "uswrf",
+#'  "uwnd", "veg", "vis", "vstm", "vvel", "vwnd", "vwsh", "wcconv", "wcinc", "wcuflx", "wcvflx", "weasd", "wvconv",
+#'  "wvinc", "wvuflx", "wvvflx").  Default is "acpcp" (precipitation).  See https://www.esrl.noaa.gov/psd/data/gridded/data.narr.monolevel.html
+#'  for variables description.
 #' @param quiet Optional. Suppresses display of messages, except for errors. Because this function can be very slow to execute, the default value is \code{FALSE}, to provide information on the downloading.
 #' @return Writes the specified files to the destination directory. If successful, returns \code{TRUE}. If unsuccessful, returns {FALSE}.
 #' @export
@@ -14,7 +21,7 @@ NARRdownloadNetCDF <- function(interval='daily',
                     startYear = 1979,
                     endYear = 1979,
                     destination='.',
-                    variable = 'precip',
+                    variable = 'acpcp',
                     quiet=FALSE){
   # check parameters
 
@@ -41,22 +48,6 @@ NARRdownloadNetCDF <- function(interval='daily',
   }
 
   variable <- stringr::str_to_lower(variable)
-  if (stringr::str_detect(variable, stringr::fixed('pre')))
-    variable <- 'acpcp'
-  else if (stringr::str_detect(variable, stringr::fixed('te')))
-    variable <- 'air.2m'
-  else if (stringr::str_detect(variable, stringr::fixed('h')))
-    variable <- 'rhum'
-  else if (stringr::str_detect(variable, stringr::fixed('wi')))
-    variable <- 'wind'
-  else if (stringr::str_detect(variable, stringr::fixed('qsi')))
-    variable <- 'dswrf'
-  else if (stringr::str_detect(variable, stringr::fixed('qli')))
-    variable <- 'dlwrf'
-  else{
-    cat('Error: variable not recognized\n')
-    return(FALSE)
-  }
 
   for (yearnum in startYear:endYear){
     if (!quiet)

--- a/R/NARRdownloadNetCDF.R
+++ b/R/NARRdownloadNetCDF.R
@@ -65,7 +65,7 @@ NARRdownloadNetCDF <- function(interval='daily',
     # create url for downloading
     file_url <- paste(url, variable,'.',yearnum,'.nc', sep='')
     destination_file <- paste(destination, variable,'.',yearnum,'.nc', sep='')
-    utils::download.file(file_url, destination_file, method='wget', quiet = quiet, mode = "w",
+    utils::download.file(file_url, destination_file, method='auto', quiet = quiet, mode = "w",
                  cacheOK = TRUE,
                  extra = getOption("download.file.extra"))
   }


### PR DESCRIPTION
I've been playing around your code and I've hit a couple of bugs which I fixed in my own forked version.  The only script changed was: `NARRdownloadNetCDF.R`

Here are the things I changed:

- `download.file` using `method = 'auto'` instead of `method = 'wget'` as `wget` failed on windows.

- `download.file` using `mode = "wb"` instead of `mode = "wb"` again because of windows, the file download with `mode = "w"` wasn't readable after ([see this](https://gis.stackexchange.com/questions/351178/reading-narr-reanalysis-data-with-raster-package-makes-r-crash))

- Change the way the variables are chosen.  Now you can and have to use the official name of the variable from [ESRL website](https://www.esrl.noaa.gov/psd/data/gridded/data.narr.monolevel.html).  I did this because you didn't support some of the variables I wanted.  It's a big change, feel free to deal with it as you please.

Do as you want with my changes, I hesitated between creating a bug report instead of a pull request.  Anyway, you know the problems now.  Also, if you accept my modifications, you may want to adapt the documentation, which I didn't touch.